### PR TITLE
Conditionset

### DIFF
--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -74,27 +74,27 @@ fn main() {
             "FixedUpdate",
             FixedTimestepStage::from_stage(Duration::from_millis(125), fixedupdate),
         )
+        // menu stuff
+        .add_system_set(
+            ConditionSet::new()
+                .run_in_state(GameState::MainMenu)
+                .with_system(exit_on_esc_system)
+                .with_system(butt_interact_visual)
+                // our menu button handlers
+                .with_system(butt_exit.run_if(on_butt_interact::<ExitButt>))
+                .with_system(butt_game.run_if(on_butt_interact::<EnterButt>))
+                .into()
+        )
+        // in-game stuff
+        .add_system_set(
+            ConditionSet::new()
+                .run_in_state(GameState::InGame)
+                .with_system(back_to_menu_on_esc)
+                .with_system(spin_sprites.run_if_not(spacebar_pressed))
+                .into()
+        )
         // our other various systems:
         .add_system(debug_current_state)
-        .add_system(exit_on_esc_system.run_in_state(GameState::MainMenu))
-        .add_system(back_to_menu_on_esc.run_in_state(GameState::InGame))
-        .add_system(
-            spin_sprites
-                .run_in_state(GameState::InGame)
-                .run_if_not(spacebar_pressed),
-        )
-        .add_system(butt_interact_visual)
-        // our menu button handlers
-        .add_system(
-            butt_exit
-                .run_in_state(GameState::MainMenu)
-                .run_if(on_butt_interact::<ExitButt>),
-        )
-        .add_system(
-            butt_game
-                .run_in_state(GameState::MainMenu)
-                .run_if(on_butt_interact::<EnterButt>),
-        )
         .run();
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod fixedtimestep;
 pub mod state;
 
 pub mod prelude {
-    pub use crate::condition::{IntoConditionalSystem, ConditionSet, AddIntoConditional};
+    pub use crate::condition::{IntoConditionalSystem, ConditionSet, AddConditionalToSet};
     #[cfg(feature = "fixedtimestep")]
     pub use crate::fixedtimestep::FixedTimestepStage;
     #[cfg(feature = "states")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod fixedtimestep;
 pub mod state;
 
 pub mod prelude {
-    pub use crate::condition::IntoConditionalSystem;
+    pub use crate::condition::{IntoConditionalSystem, ConditionSet, AddIntoConditional};
     #[cfg(feature = "fixedtimestep")]
     pub use crate::fixedtimestep::FixedTimestepStage;
     #[cfg(feature = "states")]


### PR DESCRIPTION
Condition sets allow applying many conditions onto many systems ergonomically. Similar in principle to Bevy's `SystemSet`.

`ConditionSet` lets you attach any number of Run Conditions.

When you call `.with_system`, it converts into a `ConditionSystemSet`, which no longer allows adding conditions, only systems. This is just to make the API less footgunny -- it forces users to add their conditions first, and then add their systems (which may also be conditional), avoiding syntax confusion about whether conditions apply just to one system or to the whole set.

`ConditionSystemSet` allows you to add systems using `.with_system`. It should be able to accept conditional systems as well as non-conditional systems.

TODO: is it possible to implement this somehow without requiring Rust language specialization support? How can we have both a `.with_system(ConditionalSystem)` and a `.with_system(impl IntoSystem)` ?

Internally, it converts everything into `ConditionalSystem` to store it. This is so that the conditions from the `ConditionSet` can be added to each member.

Finally, the user can call `.into()` to convert it to a Bevy `SystemSet` so that it can be added to an app/stage.