### PR TITLE
migrate some bevy changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["assets"]
 [features]
 default = [ "fixedtimestep", "states", "bevy-compat", "app" ]
 fixedtimestep = [
-    "bevy_core",
+    "bevy_time",
 ]
 states = [
     "bevy_utils",
@@ -30,8 +30,8 @@ app = [
 [dependencies]
 bevy_ecs = { git = "https://github.com/bevyengine/bevy" }
 bevy_app = { git = "https://github.com/bevyengine/bevy", optional = true }
-bevy_core = { git = "https://github.com/bevyengine/bevy", optional = true }
 bevy_utils = { git = "https://github.com/bevyengine/bevy", optional = true }
+bevy_time = { git = "https://github.com/bevyengine/bevy", optional = true }
 
 [dev-dependencies]
 bevy = { git = "https://github.com/bevyengine/bevy" }

--- a/examples/fixedtimestep.rs
+++ b/examples/fixedtimestep.rs
@@ -41,8 +41,16 @@ struct MySprite;
 
 /// Every fixed timestep, print info about the timestep parameters
 fn debug_fixed_timestep(info: Res<FixedTimestepInfo>) {
-    println!("Fixed timestep duration: {:?} ({} Hz).", info.timestep(), info.rate());
-    println!("Overstepped by {:.2?} ({:.2}%).", info.remaining(), info.overstep() * 100.0);
+    println!(
+        "Fixed timestep duration: {:?} ({} Hz).",
+        info.timestep(),
+        info.rate()
+    );
+    println!(
+        "Overstepped by {:.2?} ({:.2}%).",
+        info.remaining(),
+        info.overstep() * 100.0
+    );
 }
 
 /// Every frame, print if new MySprites have been spawned
@@ -98,5 +106,5 @@ fn reposition_entities(mut q: Query<&mut Transform, With<MySprite>>) {
 }
 
 fn setup_camera(mut commands: Commands) {
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
 }

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -12,7 +12,7 @@ use bevy::prelude::*;
 use iyes_loopless::prelude::*;
 
 use bevy::app::AppExit;
-use bevy::input::system::exit_on_esc_system;
+use bevy::window::close_on_esc;
 
 use std::time::Duration;
 
@@ -50,7 +50,7 @@ fn main() {
         // menu cleanup (state exit) systems
         .add_exit_system(GameState::MainMenu, despawn_with::<MainMenu>)
         // game setup (state enter) systems
-        .add_enter_system(GameState::InGame, setup_game_camera)
+        .add_enter_system(GameState::MainMenu, setup_camera)
         // game cleanup (state exit) systems
         .add_exit_system(GameState::InGame, despawn_with::<MySprite>)
         .add_exit_system(GameState::InGame, despawn_with::<GameCamera>)
@@ -58,12 +58,12 @@ fn main() {
         .add_system_set(
             ConditionSet::new()
                 .run_in_state(GameState::MainMenu)
-                .with_system(exit_on_esc_system)
+                .with_system(close_on_esc)
                 .with_system(butt_interact_visual)
                 // our menu button handlers
                 .with_system(butt_exit.run_if(on_butt_interact::<ExitButt>))
                 .with_system(butt_game.run_if(on_butt_interact::<EnterButt>))
-                .into()
+                .into(),
         )
         // in-game stuff
         .add_system_set(
@@ -72,12 +72,10 @@ fn main() {
                 .with_system(back_to_menu_on_esc)
                 .with_system(clear_on_del)
                 .with_system(spin_sprites.run_if_not(spacebar_pressed))
-                .into()
+                .into(),
         )
         // our other various systems:
         .add_system(debug_current_state)
-        // setup our UI camera globally at startup and keep it alive at all times
-        .add_startup_system(setup_ui_camera)
         .run();
 }
 
@@ -154,14 +152,10 @@ fn spawn_sprite(mut commands: Commands) {
         .insert(MySprite);
 }
 
-/// Spawn the UI camera
-fn setup_ui_camera(mut commands: Commands) {
-    commands.spawn_bundle(UiCameraBundle::default());
-}
-
 /// Spawn the game camera
-fn setup_game_camera(mut commands: Commands) {
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d())
+fn setup_camera(mut commands: Commands) {
+    commands
+        .spawn_bundle(Camera2dBundle::default())
         .insert(GameCamera);
 }
 
@@ -222,8 +216,8 @@ fn setup_menu(mut commands: Commands, ass: Res<AssetServer>) {
     let butt_style = Style {
         justify_content: JustifyContent::Center,
         align_items: AlignItems::Center,
-        padding: Rect::all(Val::Px(8.0)),
-        margin: Rect::all(Val::Px(4.0)),
+        padding: UiRect::all(Val::Px(8.0)),
+        margin: UiRect::all(Val::Px(4.0)),
         flex_grow: 1.0,
         ..Default::default()
     };
@@ -238,7 +232,7 @@ fn setup_menu(mut commands: Commands, ass: Res<AssetServer>) {
             color: UiColor(Color::rgb(0.5, 0.5, 0.5)),
             style: Style {
                 size: Size::new(Val::Auto, Val::Auto),
-                margin: Rect::all(Val::Auto),
+                margin: UiRect::all(Val::Auto),
                 align_self: AlignSelf::Center,
                 flex_direction: FlexDirection::ColumnReverse,
                 //align_items: AlignItems::Stretch,

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -26,8 +26,14 @@ use bevy_ecs::{
     component::ComponentId,
     event::Events,
     query::Access,
-    schedule::{SystemSet, IntoSystemDescriptor, SystemLabel, ParallelSystemDescriptorCoercion, ParallelSystemDescriptor},
-    system::{AsSystemLabel, In, IntoChainSystem, IntoSystem, Res, Resource, System, BoxedSystem, ExclusiveSystem, IntoExclusiveSystem},
+    schedule::{
+        IntoSystemDescriptor, ParallelSystemDescriptor, ParallelSystemDescriptorCoercion,
+        SystemLabel, SystemSet,
+    },
+    system::{
+        AsSystemLabel, BoxedSystem, ExclusiveSystem, In, IntoChainSystem, IntoExclusiveSystem,
+        IntoSystem, Res, Resource, System,
+    },
     world::World,
 };
 
@@ -63,38 +69,32 @@ pub struct ConditionalSystemDescriptor {
 
 impl ConditionalSystemDescriptor {
     pub fn add_label(&mut self, label: impl SystemLabel) {
-        self.label_shits.push(Box::new(move |wa| {
-            match wa {
-                BevyDescriptorWorkaround::Descriptor(x) => {
-                    BevyDescriptorWorkaround::Descriptor(x.label(label))
-                }
-                BevyDescriptorWorkaround::System(x) => {
-                    BevyDescriptorWorkaround::Descriptor(x.label(label))
-                }
+        self.label_shits.push(Box::new(move |wa| match wa {
+            BevyDescriptorWorkaround::Descriptor(x) => {
+                BevyDescriptorWorkaround::Descriptor(x.label(label))
+            }
+            BevyDescriptorWorkaround::System(x) => {
+                BevyDescriptorWorkaround::Descriptor(x.label(label))
             }
         }))
     }
     pub fn add_before<Marker>(&mut self, label: impl AsSystemLabel<Marker> + 'static) {
-        self.label_shits.push(Box::new(move |wa| {
-            match wa {
-                BevyDescriptorWorkaround::Descriptor(x) => {
-                    BevyDescriptorWorkaround::Descriptor(x.before(label))
-                }
-                BevyDescriptorWorkaround::System(x) => {
-                    BevyDescriptorWorkaround::Descriptor(x.before(label))
-                }
+        self.label_shits.push(Box::new(move |wa| match wa {
+            BevyDescriptorWorkaround::Descriptor(x) => {
+                BevyDescriptorWorkaround::Descriptor(x.before(label))
+            }
+            BevyDescriptorWorkaround::System(x) => {
+                BevyDescriptorWorkaround::Descriptor(x.before(label))
             }
         }))
     }
     pub fn add_after<Marker>(&mut self, label: impl AsSystemLabel<Marker> + 'static) {
-        self.label_shits.push(Box::new(move |wa| {
-            match wa {
-                BevyDescriptorWorkaround::Descriptor(x) => {
-                    BevyDescriptorWorkaround::Descriptor(x.after(label))
-                }
-                BevyDescriptorWorkaround::System(x) => {
-                    BevyDescriptorWorkaround::Descriptor(x.after(label))
-                }
+        self.label_shits.push(Box::new(move |wa| match wa {
+            BevyDescriptorWorkaround::Descriptor(x) => {
+                BevyDescriptorWorkaround::Descriptor(x.after(label))
+            }
+            BevyDescriptorWorkaround::System(x) => {
+                BevyDescriptorWorkaround::Descriptor(x.after(label))
             }
         }))
     }
@@ -409,10 +409,7 @@ pub trait IntoConditionalSystem<Params>: IntoSystem<(), (), Params> + Sized {
         self.into_conditional().run_if(condition)
     }
 
-    fn run_if_not<Condition, CondParams>(
-        self,
-        condition: Condition,
-    ) -> ConditionalSystemDescriptor
+    fn run_if_not<Condition, CondParams>(self, condition: Condition) -> ConditionalSystemDescriptor
     where
         Condition: IntoSystem<(), bool, CondParams>,
     {
@@ -492,7 +489,9 @@ where
 }
 
 /// Extension trait for conditional exclusive systems
-pub trait IntoConditionalExclusiveSystem<Params, SystemType>: IntoExclusiveSystem<Params, SystemType> + Sized {
+pub trait IntoConditionalExclusiveSystem<Params, SystemType>:
+    IntoExclusiveSystem<Params, SystemType> + Sized
+{
     fn into_conditional(self) -> ConditionalExclusiveSystem;
 
     fn run_if<Condition, CondParams>(self, condition: Condition) -> ConditionalExclusiveSystem
@@ -502,10 +501,7 @@ pub trait IntoConditionalExclusiveSystem<Params, SystemType>: IntoExclusiveSyste
         self.into_conditional().run_if(condition)
     }
 
-    fn run_if_not<Condition, CondParams>(
-        self,
-        condition: Condition,
-    ) -> ConditionalExclusiveSystem
+    fn run_if_not<Condition, CondParams>(self, condition: Condition) -> ConditionalExclusiveSystem
     where
         Condition: IntoSystem<(), bool, CondParams>,
     {
@@ -614,17 +610,20 @@ impl ConditionSet {
     }
 
     pub fn label(mut self, label: impl SystemLabel) -> Self {
-        self.labellers.push(Box::new(move |set: SystemSet| set.label(label)));
+        self.labellers
+            .push(Box::new(move |set: SystemSet| set.label(label)));
         self
     }
 
     pub fn before<Marker>(mut self, label: impl AsSystemLabel<Marker> + 'static) -> Self {
-        self.labellers.push(Box::new(move |set: SystemSet| set.before(label.as_system_label())));
+        self.labellers
+            .push(Box::new(move |set: SystemSet| set.before(label)));
         self
     }
 
     pub fn after<Marker>(mut self, label: impl AsSystemLabel<Marker> + 'static) -> Self {
-        self.labellers.push(Box::new(move |set: SystemSet| set.after(label.as_system_label())));
+        self.labellers
+            .push(Box::new(move |set: SystemSet| set.after(label)));
         self
     }
 }
@@ -687,7 +686,8 @@ impl AddConditionalToSet<ConditionSystemSet, ()> for ConditionalSystemDescriptor
 }
 
 impl<System, Params> AddConditionalToSet<ConditionSystemSet, Params> for System
-where System: IntoConditionalSystem<Params>,
+where
+    System: IntoConditionalSystem<Params>,
 {
     fn add_to_set(self, set: &mut ConditionSystemSet) {
         set.systems.push(self.into_conditional());
@@ -704,7 +704,8 @@ impl ConditionSet {
         // to add the condition to each system
         self.conditions.push(Box::new(move |system| {
             let condition_clone = condition.clone();
-            let condition_system = <Condition as IntoSystem<(), bool, Params>>::into_system(condition_clone);
+            let condition_system =
+                <Condition as IntoSystem<(), bool, Params>>::into_system(condition_clone);
             system.conditions.insert(0, Box::new(condition_system))
         }));
         self

--- a/src/fixedtimestep.rs
+++ b/src/fixedtimestep.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
-use bevy_core::Time;
 use bevy_ecs::prelude::*;
+use bevy_time::*;
 
 /// This type will be available as a resource, while a fixed timestep stage
 /// runs, to provide info about the current status of the fixed timestep.


### PR DESCRIPTION
1. Bevy time is now exported from `bevy_time` package https://github.com/bevyengine/bevy/commit/644bd5dbc6c281a4fae65c603f09b6666de8c566
2. Bevy removed Ortho camera and UI Camera. The 3d/2d cameras now handle UI elements https://github.com/bevyengine/bevy/pull/4745
3. `bevy::input::system::exit_on_esc_system` is now `bevy::window::close_on_esc`
4. `Rect` is now `UIRect` for UI Elements
5. `as_system_label` is now not needed. (Screenshot taken from bevy source)
<img width="911" alt="CleanShot 2022-06-14 at 13 57 27@2x" src="https://user-images.githubusercontent.com/9278174/173667700-2ad57872-6686-4f2f-b88c-ea70d56beed1.png">
