### PR TITLE
Supply extension trait for Schedule

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,9 @@ pub mod prelude {
     pub use crate::condition::{ConditionHelpers, IntoConditionalSystem, ConditionSet, AddConditionalToSet};
     #[cfg(feature = "fixedtimestep")]
     pub use crate::fixedtimestep::{FixedTimestepInfo, FixedTimestepStage};
-    #[cfg(feature = "states")]
-    pub use crate::state::{CurrentState, NextState, StateTransitionStage};
     #[cfg(feature = "app")]
     pub use crate::state::app::AppLooplessStateExt;
+    pub use crate::state::schedule::ScheduleLooplessStateExt;
+    #[cfg(feature = "states")]
+    pub use crate::state::{CurrentState, NextState, StateTransitionStage};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,16 @@ pub mod fixedtimestep;
 pub mod state;
 
 pub mod prelude {
-    pub use crate::condition::{ConditionHelpers, IntoConditionalSystem, ConditionSet, AddConditionalToSet};
+    pub use crate::condition::{
+        AddConditionalToSet, ConditionHelpers, ConditionSet, IntoConditionalSystem,
+    };
     #[cfg(feature = "fixedtimestep")]
     pub use crate::fixedtimestep::{FixedTimestepInfo, FixedTimestepStage};
     #[cfg(feature = "app")]
     pub use crate::state::app::AppLooplessStateExt;
     pub use crate::state::schedule::ScheduleLooplessStateExt;
     #[cfg(feature = "states")]
-    pub use crate::state::{CurrentState, NextState, StateTransitionStage};
+    pub use crate::state::{
+        CurrentState, NextState, StateTransitionStage, StateTransitionStageLabel,
+    };
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,5 @@
-use bevy_ecs::schedule::{Stage, StateData, IntoSystemDescriptor, SystemSet, SystemStage};
+use std::any::TypeId;
+use bevy_ecs::schedule::{StageLabel, Stage, StateData, IntoSystemDescriptor, SystemSet, SystemStage};
 use bevy_ecs::world::World;
 use bevy_utils::HashMap;
 
@@ -219,24 +220,22 @@ impl<T: StateData> Stage for StateTransitionStage<T> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, StageLabel)]
+pub struct StateTransitionStageLabel(TypeId, String);
+
+impl StateTransitionStageLabel {
+    pub fn from_type<T: StateData>() -> Self {
+        use std::any::type_name;
+        StateTransitionStageLabel(TypeId::of::<T>(), type_name::<T>().to_owned())
+    }
+}
+
 #[cfg(feature = "app")]
 pub mod app {
-    use std::any::TypeId;
-
     use bevy_ecs::schedule::{StageLabel, Stage, StateData, IntoSystemDescriptor, SystemSet};
     use bevy_app::{App, CoreStage};
 
-    use super::StateTransitionStage;
-
-    #[derive(Debug, Clone, PartialEq, Eq, Hash, StageLabel)]
-    pub struct StateTransitionStageLabel(TypeId, String);
-
-    impl StateTransitionStageLabel {
-        pub fn from_type<T: StateData>() -> Self {
-            use std::any::type_name;
-            StateTransitionStageLabel(TypeId::of::<T>(), type_name::<T>().to_owned())
-        }
-    }
+    use super::{StateTransitionStage, StateTransitionStageLabel};
 
     pub trait AppLooplessStateExt {
         /// Add a `StateTransitionStage` in the default position
@@ -341,21 +340,9 @@ pub mod app {
 }
 
 pub mod schedule {
-    use std::any::TypeId;
-
     use bevy_ecs::schedule::{StageLabel, Stage, StateData, IntoSystemDescriptor, SystemSet, Schedule};
 
-    use super::StateTransitionStage;
-
-    #[derive(Debug, Clone, PartialEq, Eq, Hash, StageLabel)]
-    pub struct StateTransitionStageLabel(TypeId, String);
-
-    impl StateTransitionStageLabel {
-        pub fn from_type<T: StateData>() -> Self {
-            use std::any::type_name;
-            StateTransitionStageLabel(TypeId::of::<T>(), type_name::<T>().to_owned())
-        }
-    }
+    use super::{StateTransitionStage, StateTransitionStageLabel};
 
     pub trait ScheduleLooplessStateExt {
         /// Add a `StateTransitionStage` after the specified stage


### PR DESCRIPTION
I am using this for the loading state schedule in `bevy_asset_loader`

Mostly a copy from the App extension trait. Just the `add_loopless_state` doesn't make much sense, since the `Schedule` might not have a `CoreStage`.