### PR TITLE
add `bevy-inspector-egui` feature, impl `Inspectable` for `NextState`, `CurrentState`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ bevy_ecs = "0.8"
 bevy_app = { version = "0.8", optional = true }
 bevy_utils = { version = "0.8", optional = true }
 bevy_time = { version = "0.8", optional = true }
+bevy-inspector-egui = { version = "0.12", optional = true, default-features = false }
 
 [dev-dependencies]
 bevy = "0.8"

--- a/src/state.rs
+++ b/src/state.rs
@@ -12,6 +12,22 @@ pub struct CurrentState<T>(pub T);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NextState<T>(pub T);
 
+#[cfg(feature = "bevy-inspector-egui")]
+impl<T: bevy_inspector_egui::Inspectable> bevy_inspector_egui::Inspectable for CurrentState<T> {
+    type Attributes = T::Attributes;
+    fn ui(&mut self, ui: &mut bevy_inspector_egui::egui::Ui, options: Self::Attributes, cx: &mut bevy_inspector_egui::Context) -> bool {
+        self.0.ui(ui, options, cx)
+    }
+}
+#[cfg(feature = "bevy-inspector-egui")]
+impl<T: bevy_inspector_egui::Inspectable> bevy_inspector_egui::Inspectable for NextState<T> {
+    type Attributes = T::Attributes;
+    fn ui(&mut self, ui: &mut bevy_inspector_egui::egui::Ui, options: Self::Attributes, cx: &mut bevy_inspector_egui::Context) -> bool {
+        self.0.ui(ui, options, cx)
+    }
+}
+
+
 /// This stage serves as the "driver" for states of a given type
 ///
 /// It will perform state transitions, based on the values of [`NextState`]


### PR DESCRIPTION
_requested in discord https://discord.com/channels/691052431525675048/1008659967546499172_

This allows inspecting these resources, using
```rust
struct Inspector {
    player_state: ResourceInspector<CurrentState<PlayerState>>
}
```