### PR TITLE
always call store_fixedtimestepinfo

### DIFF
--- a/src/fixedtimestep.rs
+++ b/src/fixedtimestep.rs
@@ -308,6 +308,8 @@ impl Stage for FixedTimestepStage {
             }
         }
 
+        self.store_fixedtimestepinfo(world);
+
         let mut n_steps = 0;
 
         while self.accumulator >= self.step {


### PR DESCRIPTION
Some use cases require checking the accumulator to see how long ago was the timestep executed. To achieve this we need to update the TimeStepInfo even if no ticks are produced.