### PR TITLE
Add `QueuedState` resource

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! Composable Alternatives to Bevy's RunCriteria, States, FixedTimestep
-//! 
+//!
 //! This crate offers alternatives to the Run Criteria, States, and FixedTimestep
 //! scheduling features currently offered by the Bevy game engine.
-//! 
+//!
 //! The ones provided by this crate do not use "looping stages", and can therefore
 //! be combined/composed together elegantly, solving some of the most annoying
 //! usability limitations of the respective APIs in Bevy.
@@ -17,19 +17,21 @@ pub mod state;
 
 /// Prelude: convenient import for all the user-facing APIs provided by the crate
 pub mod prelude {
-    pub use crate::condition::{ConditionHelpers, IntoConditionalSystem, ConditionSet, AddConditionalToSet};
+    pub use crate::condition::{
+        AddConditionalToSet, ConditionHelpers, ConditionSet, IntoConditionalSystem,
+    };
 
-    #[cfg(feature = "fixedtimestep")]
-    pub use crate::fixedtimestep::{FixedTimesteps, FixedTimestepStage};
-    #[cfg(feature = "fixedtimestep")]
-    pub use crate::fixedtimestep::schedule::ScheduleLooplessFixedTimestepExt;
     #[cfg(all(feature = "fixedtimestep", feature = "app"))]
     pub use crate::fixedtimestep::app::AppLooplessFixedTimestepExt;
+    #[cfg(feature = "fixedtimestep")]
+    pub use crate::fixedtimestep::schedule::ScheduleLooplessFixedTimestepExt;
+    #[cfg(feature = "fixedtimestep")]
+    pub use crate::fixedtimestep::{FixedTimestepStage, FixedTimesteps};
 
-    #[cfg(feature = "states")]
-    pub use crate::state::{CurrentState, NextState, StateTransitionStage};
-    #[cfg(feature = "states")]
-    pub use crate::state::schedule::ScheduleLooplessStateExt;
     #[cfg(all(feature = "states", feature = "app"))]
     pub use crate::state::app::AppLooplessStateExt;
+    #[cfg(feature = "states")]
+    pub use crate::state::schedule::ScheduleLooplessStateExt;
+    #[cfg(feature = "states")]
+    pub use crate::state::{CurrentState, NextState, StateTransitionStage, WaitingState};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,5 +33,5 @@ pub mod prelude {
     #[cfg(feature = "states")]
     pub use crate::state::schedule::ScheduleLooplessStateExt;
     #[cfg(feature = "states")]
-    pub use crate::state::{CurrentState, NextState, StateTransitionStage, WaitingState};
+    pub use crate::state::{CurrentState, NextState, QueuedState, StateTransitionStage};
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -27,7 +27,7 @@ pub struct NextState<T>(pub T);
 
 /// A resource available to exit states, indicating what state is being transitioned to
 #[derive(Debug, Clone, PartialEq, Eq, Resource)]
-pub struct WaitingState<T>(pub T);
+pub struct QueuedState<T>(pub T);
 
 #[cfg(feature = "bevy-inspector-egui")]
 impl<T: bevy_inspector_egui::Inspectable> bevy_inspector_egui::Inspectable for CurrentState<T> {
@@ -54,7 +54,7 @@ impl<T: bevy_inspector_egui::Inspectable> bevy_inspector_egui::Inspectable for N
     }
 }
 #[cfg(feature = "bevy-inspector-egui")]
-impl<T: bevy_inspector_egui::Inspectable> bevy_inspector_egui::Inspectable for WaitingState<T> {
+impl<T: bevy_inspector_egui::Inspectable> bevy_inspector_egui::Inspectable for QueuedState<T> {
     type Attributes = T::Attributes;
     fn ui(
         &mut self,
@@ -280,12 +280,12 @@ impl<T: StateData> Stage for StateTransitionStage<T> {
             let next = world.remove_resource::<NextState<T>>();
 
             if let Some(NextState(next)) = next {
-                world.insert_resource(WaitingState(next.clone()));
+                world.insert_resource(QueuedState(next.clone()));
                 if let Some(stage) = self.exit_stages.get_mut(&current) {
                     stage.run(world);
                 }
 
-                world.remove_resource::<WaitingState<T>>();
+                world.remove_resource::<QueuedState<T>>();
                 world.insert_resource(CurrentState(next.clone()));
 
                 if let Some(stage) = self.enter_stages.get_mut(&next) {

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,38 +8,63 @@
 //! aspects of your application) and combine them trivially.
 //!
 //! (see `examples/menu.rs` for a full example)
-use bevy_ecs::schedule::{Stage, StateData, StageLabel, IntoSystemDescriptor, SystemSet, SystemStage};
-use bevy_ecs::world::World;
+use bevy_ecs::schedule::{
+    IntoSystemDescriptor, Stage, StageLabel, StateData, SystemSet, SystemStage,
+};
 use bevy_ecs::system::Resource;
+use bevy_ecs::world::World;
 use bevy_utils::HashMap;
 
 use std::any::TypeId;
 
 /// This will be available as a resource, indicating the current state
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[derive(Resource)]
+#[derive(Debug, Clone, PartialEq, Eq, Resource)]
 pub struct CurrentState<T>(pub T);
 
 /// When you want to change state, insert this as a resource
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[derive(Resource)]
+#[derive(Debug, Clone, PartialEq, Eq, Resource)]
 pub struct NextState<T>(pub T);
+
+/// A resource available to exit states, indicating what state is being transitioned to
+#[derive(Debug, Clone, PartialEq, Eq, Resource)]
+pub struct WaitingState<T>(pub T);
 
 #[cfg(feature = "bevy-inspector-egui")]
 impl<T: bevy_inspector_egui::Inspectable> bevy_inspector_egui::Inspectable for CurrentState<T> {
     type Attributes = T::Attributes;
-    fn ui(&mut self, ui: &mut bevy_inspector_egui::egui::Ui, options: Self::Attributes, cx: &mut bevy_inspector_egui::Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut bevy_inspector_egui::egui::Ui,
+        options: Self::Attributes,
+        cx: &mut bevy_inspector_egui::Context,
+    ) -> bool {
         self.0.ui(ui, options, cx)
     }
 }
 #[cfg(feature = "bevy-inspector-egui")]
 impl<T: bevy_inspector_egui::Inspectable> bevy_inspector_egui::Inspectable for NextState<T> {
     type Attributes = T::Attributes;
-    fn ui(&mut self, ui: &mut bevy_inspector_egui::egui::Ui, options: Self::Attributes, cx: &mut bevy_inspector_egui::Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut bevy_inspector_egui::egui::Ui,
+        options: Self::Attributes,
+        cx: &mut bevy_inspector_egui::Context,
+    ) -> bool {
         self.0.ui(ui, options, cx)
     }
 }
-
+#[cfg(feature = "bevy-inspector-egui")]
+impl<T: bevy_inspector_egui::Inspectable> bevy_inspector_egui::Inspectable for WaitingState<T> {
+    type Attributes = T::Attributes;
+    fn ui(
+        &mut self,
+        ui: &mut bevy_inspector_egui::egui::Ui,
+        options: Self::Attributes,
+        cx: &mut bevy_inspector_egui::Context,
+    ) -> bool {
+        self.0.ui(ui, options, cx)
+    }
+}
 
 /// This stage serves as the "driver" for states of a given type
 ///
@@ -114,12 +139,18 @@ impl<T: StateData> StateTransitionStage<T> {
     /// of type other than `SystemStage`.
     ///
     /// Will create the enter `SystemStage` if it does not exist.
-    pub fn add_enter_system<Params>(&mut self, state: T, system: impl IntoSystemDescriptor<Params>) {
+    pub fn add_enter_system<Params>(
+        &mut self,
+        state: T,
+        system: impl IntoSystemDescriptor<Params>,
+    ) {
         if !self.enter_stages.contains_key(&state) {
             self.set_enter_stage(state.clone(), SystemStage::parallel());
         }
 
-        let stage = self.enter_stages.get_mut(&state)
+        let stage = self
+            .enter_stages
+            .get_mut(&state)
             .expect("No enter stage for state.")
             .downcast_mut::<SystemStage>()
             .expect("State enter stage is not a SystemStage");
@@ -138,7 +169,9 @@ impl<T: StateData> StateTransitionStage<T> {
             self.set_exit_stage(state.clone(), SystemStage::parallel());
         }
 
-        let stage = self.exit_stages.get_mut(&state)
+        let stage = self
+            .exit_stages
+            .get_mut(&state)
             .expect("No exit stage for state.")
             .downcast_mut::<SystemStage>()
             .expect("State exit stage is not a SystemStage");
@@ -160,7 +193,9 @@ impl<T: StateData> StateTransitionStage<T> {
             self.set_enter_stage(state.clone(), SystemStage::parallel());
         }
 
-        let stage = self.enter_stages.get_mut(&state)
+        let stage = self
+            .enter_stages
+            .get_mut(&state)
             .expect("No enter stage for state.")
             .downcast_mut::<SystemStage>()
             .expect("State enter stage is not a SystemStage");
@@ -182,7 +217,9 @@ impl<T: StateData> StateTransitionStage<T> {
             self.set_exit_stage(state.clone(), SystemStage::parallel());
         }
 
-        let stage = self.exit_stages.get_mut(&state)
+        let stage = self
+            .exit_stages
+            .get_mut(&state)
             .expect("No exit stage for state.")
             .downcast_mut::<SystemStage>()
             .expect("State exit stage is not a SystemStage");
@@ -191,13 +228,21 @@ impl<T: StateData> StateTransitionStage<T> {
     }
 
     /// Builder version of `add_enter_system`
-    pub fn with_enter_system<Params>(mut self, state: T, system: impl IntoSystemDescriptor<Params>) -> Self {
+    pub fn with_enter_system<Params>(
+        mut self,
+        state: T,
+        system: impl IntoSystemDescriptor<Params>,
+    ) -> Self {
         self.add_enter_system(state, system);
         self
     }
 
     /// Builder version of `add_exit_system`
-    pub fn with_exit_system<Params>(mut self, state: T, system: impl IntoSystemDescriptor<Params>) -> Self {
+    pub fn with_exit_system<Params>(
+        mut self,
+        state: T,
+        system: impl IntoSystemDescriptor<Params>,
+    ) -> Self {
         self.add_exit_system(state, system);
         self
     }
@@ -235,10 +280,12 @@ impl<T: StateData> Stage for StateTransitionStage<T> {
             let next = world.remove_resource::<NextState<T>>();
 
             if let Some(NextState(next)) = next {
+                world.insert_resource(WaitingState(next.clone()));
                 if let Some(stage) = self.exit_stages.get_mut(&current) {
                     stage.run(world);
                 }
 
+                world.remove_resource::<WaitingState<T>>();
                 world.insert_resource(CurrentState(next.clone()));
 
                 if let Some(stage) = self.enter_stages.get_mut(&next) {
@@ -273,8 +320,8 @@ impl StateTransitionStageLabel {
 /// Extensions to `bevy_app`
 #[cfg(feature = "app")]
 pub mod app {
-    use bevy_ecs::schedule::{StageLabel, Stage, StateData, IntoSystemDescriptor, SystemSet};
     use bevy_app::{App, CoreStage};
+    use bevy_ecs::schedule::{IntoSystemDescriptor, Stage, StageLabel, StateData, SystemSet};
 
     use super::{StateTransitionStage, StateTransitionStageLabel};
 
@@ -285,29 +332,53 @@ pub mod app {
         /// (before `CoreStage::Update`)
         fn add_loopless_state<T: StateData>(&mut self, init: T) -> &mut App;
         /// Add a `StateTransitionStage` after the specified stage
-        fn add_loopless_state_after_stage<T: StateData>(&mut self, stage: impl StageLabel, init: T) -> &mut App;
+        fn add_loopless_state_after_stage<T: StateData>(
+            &mut self,
+            stage: impl StageLabel,
+            init: T,
+        ) -> &mut App;
         /// Add a `StateTransitionStage` before the specified stage
-        fn add_loopless_state_before_stage<T: StateData>(&mut self, stage: impl StageLabel, init: T) -> &mut App;
+        fn add_loopless_state_before_stage<T: StateData>(
+            &mut self,
+            stage: impl StageLabel,
+            init: T,
+        ) -> &mut App;
         /// Add an enter system for the given state
         ///
         /// Requires the stage to be labeled with a `StateTransitionStageLabel`
         /// (as done by the `add_loopless_state*` methods).
-        fn add_enter_system<T: StateData, Params>(&mut self, state: T, system: impl IntoSystemDescriptor<Params>) -> &mut App;
+        fn add_enter_system<T: StateData, Params>(
+            &mut self,
+            state: T,
+            system: impl IntoSystemDescriptor<Params>,
+        ) -> &mut App;
         /// Add an exit system for the given state
         ///
         /// Requires the stage to be labeled with a `StateTransitionStageLabel`
         /// (as done by the `add_loopless_state*` methods).
-        fn add_exit_system<T: StateData, Params>(&mut self, state: T, system: impl IntoSystemDescriptor<Params>) -> &mut App;
+        fn add_exit_system<T: StateData, Params>(
+            &mut self,
+            state: T,
+            system: impl IntoSystemDescriptor<Params>,
+        ) -> &mut App;
         /// Add an enter system set for the given state
         ///
         /// Requires the stage to be labeled with a `StateTransitionStageLabel`
         /// (as done by the `add_loopless_state*` methods).
-        fn add_enter_system_set<T: StateData>(&mut self, state: T, system_set: SystemSet) -> &mut App;
+        fn add_enter_system_set<T: StateData>(
+            &mut self,
+            state: T,
+            system_set: SystemSet,
+        ) -> &mut App;
         /// Add an exit system set for the given state
         ///
         /// Requires the stage to be labeled with a `StateTransitionStageLabel`
         /// (as done by the `add_loopless_state*` methods).
-        fn add_exit_system_set<T: StateData>(&mut self, state: T, system_set: SystemSet) -> &mut App;
+        fn add_exit_system_set<T: StateData>(
+            &mut self,
+            state: T,
+            system_set: SystemSet,
+        ) -> &mut App;
         /// Add a custom stage to execute for the given state
         ///
         /// Requires the stage to be labeled with a `StateTransitionStageLabel`
@@ -328,52 +399,100 @@ pub mod app {
         fn add_loopless_state<T: StateData>(&mut self, init: T) -> &mut App {
             self.add_loopless_state_before_stage(CoreStage::Update, init)
         }
-        fn add_loopless_state_after_stage<T: StateData>(&mut self, stage: impl StageLabel, init: T) -> &mut App {
+        fn add_loopless_state_after_stage<T: StateData>(
+            &mut self,
+            stage: impl StageLabel,
+            init: T,
+        ) -> &mut App {
             self.add_stage_after(
                 stage,
                 StateTransitionStageLabel::from_type::<T>(),
-                StateTransitionStage::new(init)
+                StateTransitionStage::new(init),
             )
         }
-        fn add_loopless_state_before_stage<T: StateData>(&mut self, stage: impl StageLabel, init: T) -> &mut App {
+        fn add_loopless_state_before_stage<T: StateData>(
+            &mut self,
+            stage: impl StageLabel,
+            init: T,
+        ) -> &mut App {
             self.add_stage_before(
                 stage,
                 StateTransitionStageLabel::from_type::<T>(),
-                StateTransitionStage::new(init)
+                StateTransitionStage::new(init),
             )
         }
-        fn add_enter_system<T: StateData, Params>(&mut self, state: T, system: impl IntoSystemDescriptor<Params>) -> &mut App {
-            let stage = self.schedule.get_stage_mut::<StateTransitionStage<T>>(StateTransitionStageLabel::from_type::<T>())
+        fn add_enter_system<T: StateData, Params>(
+            &mut self,
+            state: T,
+            system: impl IntoSystemDescriptor<Params>,
+        ) -> &mut App {
+            let stage = self
+                .schedule
+                .get_stage_mut::<StateTransitionStage<T>>(
+                    StateTransitionStageLabel::from_type::<T>(),
+                )
                 .expect("State Transition Stage not found (assuming auto-added label)");
             stage.add_enter_system(state, system);
             self
         }
-        fn add_exit_system<T: StateData, Params>(&mut self, state: T, system: impl IntoSystemDescriptor<Params>) -> &mut App {
-            let stage = self.schedule.get_stage_mut::<StateTransitionStage<T>>(StateTransitionStageLabel::from_type::<T>())
+        fn add_exit_system<T: StateData, Params>(
+            &mut self,
+            state: T,
+            system: impl IntoSystemDescriptor<Params>,
+        ) -> &mut App {
+            let stage = self
+                .schedule
+                .get_stage_mut::<StateTransitionStage<T>>(
+                    StateTransitionStageLabel::from_type::<T>(),
+                )
                 .expect("State Transition Stage not found (assuming auto-added label)");
             stage.add_exit_system(state, system);
             self
         }
-        fn add_enter_system_set<T: StateData>(&mut self, state: T, system_set: SystemSet) -> &mut App {
-            let stage = self.schedule.get_stage_mut::<StateTransitionStage<T>>(StateTransitionStageLabel::from_type::<T>())
+        fn add_enter_system_set<T: StateData>(
+            &mut self,
+            state: T,
+            system_set: SystemSet,
+        ) -> &mut App {
+            let stage = self
+                .schedule
+                .get_stage_mut::<StateTransitionStage<T>>(
+                    StateTransitionStageLabel::from_type::<T>(),
+                )
                 .expect("State Transition Stage not found (assuming auto-added label)");
             stage.add_enter_system_set(state, system_set);
             self
         }
-        fn add_exit_system_set<T: StateData>(&mut self, state: T, system_set: SystemSet) -> &mut App {
-            let stage = self.schedule.get_stage_mut::<StateTransitionStage<T>>(StateTransitionStageLabel::from_type::<T>())
+        fn add_exit_system_set<T: StateData>(
+            &mut self,
+            state: T,
+            system_set: SystemSet,
+        ) -> &mut App {
+            let stage = self
+                .schedule
+                .get_stage_mut::<StateTransitionStage<T>>(
+                    StateTransitionStageLabel::from_type::<T>(),
+                )
                 .expect("State Transition Stage not found (assuming auto-added label)");
             stage.add_exit_system_set(state, system_set);
             self
         }
         fn set_enter_stage<T: StateData>(&mut self, state: T, enter_stage: impl Stage) -> &mut App {
-            let stage = self.schedule.get_stage_mut::<StateTransitionStage<T>>(StateTransitionStageLabel::from_type::<T>())
+            let stage = self
+                .schedule
+                .get_stage_mut::<StateTransitionStage<T>>(
+                    StateTransitionStageLabel::from_type::<T>(),
+                )
                 .expect("State Transition Stage not found (assuming auto-added label)");
             stage.set_enter_stage(state, enter_stage);
             self
         }
         fn set_exit_stage<T: StateData>(&mut self, state: T, exit_stage: impl Stage) -> &mut App {
-            let stage = self.schedule.get_stage_mut::<StateTransitionStage<T>>(StateTransitionStageLabel::from_type::<T>())
+            let stage = self
+                .schedule
+                .get_stage_mut::<StateTransitionStage<T>>(
+                    StateTransitionStageLabel::from_type::<T>(),
+                )
                 .expect("State Transition Stage not found (assuming auto-added label)");
             stage.set_exit_stage(state, exit_stage);
             self
@@ -383,36 +502,62 @@ pub mod app {
 
 /// Extensions to Bevy Schedule
 pub mod schedule {
-    use bevy_ecs::schedule::{StageLabel, Stage, StateData, IntoSystemDescriptor, SystemSet, Schedule};
+    use bevy_ecs::schedule::{
+        IntoSystemDescriptor, Schedule, Stage, StageLabel, StateData, SystemSet,
+    };
 
     use super::{StateTransitionStage, StateTransitionStageLabel};
 
     /// Extension trait with the methods to add to Bevy's `Schedule`
     pub trait ScheduleLooplessStateExt {
         /// Add a `StateTransitionStage` after the specified stage
-        fn add_loopless_state_after_stage<T: StateData>(&mut self, stage: impl StageLabel, init: T) -> &mut Schedule;
+        fn add_loopless_state_after_stage<T: StateData>(
+            &mut self,
+            stage: impl StageLabel,
+            init: T,
+        ) -> &mut Schedule;
         /// Add a `StateTransitionStage` before the specified stage
-        fn add_loopless_state_before_stage<T: StateData>(&mut self, stage: impl StageLabel, init: T) -> &mut Schedule;
+        fn add_loopless_state_before_stage<T: StateData>(
+            &mut self,
+            stage: impl StageLabel,
+            init: T,
+        ) -> &mut Schedule;
         /// Add an enter system for the given state
         ///
         /// Requires the stage to be labeled with a `StateTransitionStageLabel`
         /// (as done by the `add_loopless_state*` methods).
-        fn add_enter_system<T: StateData, Params>(&mut self, state: T, system: impl IntoSystemDescriptor<Params>) -> &mut Schedule;
+        fn add_enter_system<T: StateData, Params>(
+            &mut self,
+            state: T,
+            system: impl IntoSystemDescriptor<Params>,
+        ) -> &mut Schedule;
         /// Add an exit system for the given state
         ///
         /// Requires the stage to be labeled with a `StateTransitionStageLabel`
         /// (as done by the `add_loopless_state*` methods).
-        fn add_exit_system<T: StateData, Params>(&mut self, state: T, system: impl IntoSystemDescriptor<Params>) -> &mut Schedule;
+        fn add_exit_system<T: StateData, Params>(
+            &mut self,
+            state: T,
+            system: impl IntoSystemDescriptor<Params>,
+        ) -> &mut Schedule;
         /// Add an enter system set for the given state
         ///
         /// Requires the stage to be labeled with a `StateTransitionStageLabel`
         /// (as done by the `add_loopless_state*` methods).
-        fn add_enter_system_set<T: StateData>(&mut self, state: T, system_set: SystemSet) -> &mut Schedule;
+        fn add_enter_system_set<T: StateData>(
+            &mut self,
+            state: T,
+            system_set: SystemSet,
+        ) -> &mut Schedule;
         /// Add an exit system set for the given state
         ///
         /// Requires the stage to be labeled with a `StateTransitionStageLabel`
         /// (as done by the `add_loopless_state*` methods).
-        fn add_exit_system_set<T: StateData>(&mut self, state: T, system_set: SystemSet) -> &mut Schedule;
+        fn add_exit_system_set<T: StateData>(
+            &mut self,
+            state: T,
+            system_set: SystemSet,
+        ) -> &mut Schedule;
         /// Add a custom stage to execute for the given state
         ///
         /// Requires the stage to be labeled with a `StateTransitionStageLabel`
@@ -430,52 +575,102 @@ pub mod schedule {
     }
 
     impl ScheduleLooplessStateExt for Schedule {
-        fn add_loopless_state_after_stage<T: StateData>(&mut self, stage: impl StageLabel, init: T) -> &mut Schedule {
+        fn add_loopless_state_after_stage<T: StateData>(
+            &mut self,
+            stage: impl StageLabel,
+            init: T,
+        ) -> &mut Schedule {
             self.add_stage_after(
                 stage,
                 StateTransitionStageLabel::from_type::<T>(),
-                StateTransitionStage::new(init)
+                StateTransitionStage::new(init),
             )
         }
-        fn add_loopless_state_before_stage<T: StateData>(&mut self, stage: impl StageLabel, init: T) -> &mut Schedule {
+        fn add_loopless_state_before_stage<T: StateData>(
+            &mut self,
+            stage: impl StageLabel,
+            init: T,
+        ) -> &mut Schedule {
             self.add_stage_before(
                 stage,
                 StateTransitionStageLabel::from_type::<T>(),
-                StateTransitionStage::new(init)
+                StateTransitionStage::new(init),
             )
         }
-        fn add_enter_system<T: StateData, Params>(&mut self, state: T, system: impl IntoSystemDescriptor<Params>) -> &mut Schedule {
-            let stage = self.get_stage_mut::<StateTransitionStage<T>>(StateTransitionStageLabel::from_type::<T>())
+        fn add_enter_system<T: StateData, Params>(
+            &mut self,
+            state: T,
+            system: impl IntoSystemDescriptor<Params>,
+        ) -> &mut Schedule {
+            let stage = self
+                .get_stage_mut::<StateTransitionStage<T>>(
+                    StateTransitionStageLabel::from_type::<T>(),
+                )
                 .expect("State Transition Stage not found (assuming auto-added label)");
             stage.add_enter_system(state, system);
             self
         }
-        fn add_exit_system<T: StateData, Params>(&mut self, state: T, system: impl IntoSystemDescriptor<Params>) -> &mut Schedule {
-            let stage = self.get_stage_mut::<StateTransitionStage<T>>(StateTransitionStageLabel::from_type::<T>())
+        fn add_exit_system<T: StateData, Params>(
+            &mut self,
+            state: T,
+            system: impl IntoSystemDescriptor<Params>,
+        ) -> &mut Schedule {
+            let stage = self
+                .get_stage_mut::<StateTransitionStage<T>>(
+                    StateTransitionStageLabel::from_type::<T>(),
+                )
                 .expect("State Transition Stage not found (assuming auto-added label)");
             stage.add_exit_system(state, system);
             self
         }
-        fn add_enter_system_set<T: StateData>(&mut self, state: T, system_set: SystemSet) -> &mut Schedule {
-            let stage = self.get_stage_mut::<StateTransitionStage<T>>(StateTransitionStageLabel::from_type::<T>())
+        fn add_enter_system_set<T: StateData>(
+            &mut self,
+            state: T,
+            system_set: SystemSet,
+        ) -> &mut Schedule {
+            let stage = self
+                .get_stage_mut::<StateTransitionStage<T>>(
+                    StateTransitionStageLabel::from_type::<T>(),
+                )
                 .expect("State Transition Stage not found (assuming auto-added label)");
             stage.add_enter_system_set(state, system_set);
             self
         }
-        fn add_exit_system_set<T: StateData>(&mut self, state: T, system_set: SystemSet) -> &mut Schedule {
-            let stage = self.get_stage_mut::<StateTransitionStage<T>>(StateTransitionStageLabel::from_type::<T>())
+        fn add_exit_system_set<T: StateData>(
+            &mut self,
+            state: T,
+            system_set: SystemSet,
+        ) -> &mut Schedule {
+            let stage = self
+                .get_stage_mut::<StateTransitionStage<T>>(
+                    StateTransitionStageLabel::from_type::<T>(),
+                )
                 .expect("State Transition Stage not found (assuming auto-added label)");
             stage.add_exit_system_set(state, system_set);
             self
         }
-        fn set_enter_stage<T: StateData>(&mut self, state: T, enter_stage: impl Stage) -> &mut Schedule {
-            let stage = self.get_stage_mut::<StateTransitionStage<T>>(StateTransitionStageLabel::from_type::<T>())
+        fn set_enter_stage<T: StateData>(
+            &mut self,
+            state: T,
+            enter_stage: impl Stage,
+        ) -> &mut Schedule {
+            let stage = self
+                .get_stage_mut::<StateTransitionStage<T>>(
+                    StateTransitionStageLabel::from_type::<T>(),
+                )
                 .expect("State Transition Stage not found (assuming auto-added label)");
             stage.set_enter_stage(state, enter_stage);
             self
         }
-        fn set_exit_stage<T: StateData>(&mut self, state: T, exit_stage: impl Stage) -> &mut Schedule {
-            let stage = self.get_stage_mut::<StateTransitionStage<T>>(StateTransitionStageLabel::from_type::<T>())
+        fn set_exit_stage<T: StateData>(
+            &mut self,
+            state: T,
+            exit_stage: impl Stage,
+        ) -> &mut Schedule {
+            let stage = self
+                .get_stage_mut::<StateTransitionStage<T>>(
+                    StateTransitionStageLabel::from_type::<T>(),
+                )
                 .expect("State Transition Stage not found (assuming auto-added label)");
             stage.set_exit_stage(state, exit_stage);
             self


### PR DESCRIPTION
Add a `QueuedState` resource that is only available to exit systems which contains the state being transitioned to.  Somewhat related to #8 which has been reverted since it was closed. 

Also `cargo fmt` happened, I can undo the formatting if needed :sweat_smile: 